### PR TITLE
Added a customizable function for parsing the request URL

### DIFF
--- a/basculehttp/constructor_test.go
+++ b/basculehttp/constructor_test.go
@@ -23,7 +23,7 @@ func TestConstructor(t *testing.T) {
 		WithCLogger(func(_ context.Context) bascule.Logger {
 			return bascule.Logger(log.NewJSONLogger(log.NewSyncWriter(os.Stdout)))
 		}),
-		WithGetURLFunc(CreateRemovePrefixURLFunc("/test")),
+		WithParseURLFunc(CreateRemovePrefixURLFunc("/test", DefaultParseURLFunc)),
 		WithCErrorResponseFunc(DefaultOnErrorResponse),
 	)
 	c2 := NewConstructor(

--- a/basculehttp/constructor_test.go
+++ b/basculehttp/constructor_test.go
@@ -15,6 +15,7 @@ import (
 func TestConstructor(t *testing.T) {
 	testHeader := "test header"
 	testDelimiter := "="
+
 	c := NewConstructor(
 		WithHeaderName(testHeader),
 		WithHeaderDelimiter(testDelimiter),
@@ -22,6 +23,7 @@ func TestConstructor(t *testing.T) {
 		WithCLogger(func(_ context.Context) bascule.Logger {
 			return bascule.Logger(log.NewJSONLogger(log.NewSyncWriter(os.Stdout)))
 		}),
+		WithGetURLFunc(CreateRemovePrefixURLFunc("/test")),
 		WithCErrorResponseFunc(DefaultOnErrorResponse),
 	)
 	c2 := NewConstructor(
@@ -35,6 +37,7 @@ func TestConstructor(t *testing.T) {
 		requestHeaderKey   string
 		requestHeaderValue string
 		expectedStatusCode int
+		endpoint           string
 	}{
 		{
 			description:        "Success",
@@ -42,6 +45,13 @@ func TestConstructor(t *testing.T) {
 			requestHeaderKey:   testHeader,
 			requestHeaderValue: "Basic=Y29kZXg6Y29kZXg=",
 			expectedStatusCode: http.StatusOK,
+			endpoint:           "/test",
+		},
+		{
+			description:        "URL Parsing Error",
+			constructor:        c,
+			endpoint:           "/blah",
+			expectedStatusCode: http.StatusForbidden,
 		},
 		{
 			description:        "No Authorization Header Error",
@@ -49,6 +59,7 @@ func TestConstructor(t *testing.T) {
 			requestHeaderKey:   DefaultHeaderName,
 			requestHeaderValue: "",
 			expectedStatusCode: http.StatusForbidden,
+			endpoint:           "/",
 		},
 		{
 			description:        "No Space in Auth Header Error",
@@ -56,6 +67,7 @@ func TestConstructor(t *testing.T) {
 			requestHeaderKey:   testHeader,
 			requestHeaderValue: "abcd",
 			expectedStatusCode: http.StatusBadRequest,
+			endpoint:           "/test",
 		},
 		{
 			description:        "Key Not Supported Error",
@@ -63,6 +75,7 @@ func TestConstructor(t *testing.T) {
 			requestHeaderKey:   DefaultHeaderName,
 			requestHeaderValue: "abcd ",
 			expectedStatusCode: http.StatusForbidden,
+			endpoint:           "/test",
 		},
 		{
 			description:        "Parse and Validate Error",
@@ -70,6 +83,7 @@ func TestConstructor(t *testing.T) {
 			requestHeaderKey:   testHeader,
 			requestHeaderValue: "Basic=AFJDK",
 			expectedStatusCode: http.StatusForbidden,
+			endpoint:           "/test",
 		},
 	}
 	for _, tc := range tests {
@@ -78,7 +92,7 @@ func TestConstructor(t *testing.T) {
 			handler := tc.constructor(next)
 
 			writer := httptest.NewRecorder()
-			req := httptest.NewRequest("get", "/", nil)
+			req := httptest.NewRequest("get", tc.endpoint, nil)
 			req.Header.Add(tc.requestHeaderKey, tc.requestHeaderValue)
 			handler.ServeHTTP(writer, req)
 			assert.Equal(tc.expectedStatusCode, writer.Code)

--- a/basculehttp/errorResponseReason.go
+++ b/basculehttp/errorResponseReason.go
@@ -11,6 +11,7 @@ const (
 	InvalidHeader
 	KeyNotSupported
 	ParseFailed
+	GetURLFailed
 	MissingAuthentication
 	ChecksNotFound
 	ChecksFailed

--- a/basculehttp/errorresponsereason_string.go
+++ b/basculehttp/errorresponsereason_string.go
@@ -4,9 +4,23 @@ package basculehttp
 
 import "strconv"
 
-const _ErrorResponseReason_name = "MissingHeaderInvalidHeaderKeyNotSupportedParseFailedMissingAuthenticationChecksNotFoundChecksFailed"
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[MissingHeader-0]
+	_ = x[InvalidHeader-1]
+	_ = x[KeyNotSupported-2]
+	_ = x[ParseFailed-3]
+	_ = x[GetURLFailed-4]
+	_ = x[MissingAuthentication-5]
+	_ = x[ChecksNotFound-6]
+	_ = x[ChecksFailed-7]
+}
 
-var _ErrorResponseReason_index = [...]uint8{0, 13, 26, 41, 52, 73, 87, 99}
+const _ErrorResponseReason_name = "MissingHeaderInvalidHeaderKeyNotSupportedParseFailedGetURLFailedMissingAuthenticationChecksNotFoundChecksFailed"
+
+var _ErrorResponseReason_index = [...]uint8{0, 13, 26, 41, 52, 64, 85, 99, 111}
 
 func (i ErrorResponseReason) String() string {
 	if i < 0 || i >= ErrorResponseReason(len(_ErrorResponseReason_index)-1) {

--- a/basculehttp/listener_test.go
+++ b/basculehttp/listener_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,11 +30,14 @@ func TestListenerDecorator(t *testing.T) {
 	handler.ServeHTTP(writer, req)
 	assert.Equal(http.StatusForbidden, writer.Code)
 
+	u, err := url.ParseRequestURI("/")
+	assert.Nil(err)
+
 	ctx := bascule.WithAuthentication(context.Background(), bascule.Authentication{
 		Authorization: "jwt",
 		Token:         bascule.NewToken("", "", bascule.Attributes{}),
 		Request: bascule.Request{
-			URL:    "/",
+			URL:    u,
 			Method: "get",
 		},
 	})

--- a/basculehttp/notfoundbehavior_string.go
+++ b/basculehttp/notfoundbehavior_string.go
@@ -4,6 +4,14 @@ package basculehttp
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Forbid-0]
+	_ = x[Allow-1]
+}
+
 const _NotFoundBehavior_name = "ForbidAllow"
 
 var _NotFoundBehavior_index = [...]uint8{0, 6, 11}

--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package bascule
 
 import (
 	"context"
+	"net/url"
 )
 
 // Authorization represents the authorization mechanism performed on the token,
@@ -18,7 +19,7 @@ type Authentication struct {
 // Request holds request information that may be useful for validating the
 // token.
 type Request struct {
-	URL    string
+	URL    *url.URL
 	Method string
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package bascule
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,8 @@ import (
 
 func TestContext(t *testing.T) {
 	assert := assert.New(t)
+	u, err := url.ParseRequestURI("/a/b/c")
+	assert.Nil(err)
 	expectedAuth := Authentication{
 		Authorization: "authorization string",
 		Token: simpleToken{
@@ -17,7 +20,7 @@ func TestContext(t *testing.T) {
 			attributes: map[string]interface{}{"testkey": "testval", "attr": 5},
 		},
 		Request: Request{
-			URL:    "/a/b/c",
+			URL:    u,
 			Method: "GET",
 		},
 	}


### PR DESCRIPTION
This will help us get rid of prefixes on request urls (like `/api/v1`) before adding them to the context for easier parsing against capabilities for XMiDT/Codex services.