### PR TITLE
Unit tests

### DIFF
--- a/basculehttp/basicTokenFactory.go
+++ b/basculehttp/basicTokenFactory.go
@@ -36,10 +36,14 @@ var (
 	ErrorInvalidPassword   = errors.New("invalid password")
 )
 
+type EncodedBasicKeys struct {
+	Basic []string
+}
+
 // EncodedBasicKeysIn contains string representations of the basic auth allowed.
 type EncodedBasicKeysIn struct {
 	fx.In
-	Basic []string
+	Keys EncodedBasicKeys `name:"encoded_basic_auths"`
 }
 
 // TokenFactoryFunc makes it so any function that has the same signature as
@@ -120,15 +124,15 @@ func ProvideBasicTokenFactory(key string) fx.Option {
 	return fx.Provide(
 		fx.Annotated{
 			Name:   "encoded_basic_auths",
-			Target: arrange.UnmarshalKey(key, EncodedBasicKeysIn{}),
+			Target: arrange.UnmarshalKey(key, EncodedBasicKeys{}),
 		},
 		fx.Annotated{
 			Group: "bascule_constructor_options",
 			Target: func(in EncodedBasicKeysIn) (COption, error) {
-				if len(in.Basic) == 0 {
+				if len(in.Keys.Basic) == 0 {
 					return nil, nil
 				}
-				tf, err := NewBasicTokenFactoryFromList(in.Basic)
+				tf, err := NewBasicTokenFactoryFromList(in.Keys.Basic)
 				if err != nil {
 					return nil, err
 				}

--- a/basculehttp/basicTokenFactory.go
+++ b/basculehttp/basicTokenFactory.go
@@ -136,7 +136,7 @@ func ProvideBasicTokenFactory(key string) fx.Option {
 				if err != nil {
 					return nil, err
 				}
-				return WithTokenFactory("Basic", tf), nil
+				return WithTokenFactory(BasicAuthorization, tf), nil
 			},
 		},
 	)

--- a/basculehttp/bearerTokenFactory.go
+++ b/basculehttp/bearerTokenFactory.go
@@ -136,7 +136,7 @@ func ProvideBearerTokenFactory(configKey string, optional bool) fx.Option {
 						}
 						return nil, ErrNilResolver
 					}
-					return WithTokenFactory("Bearer", f), nil
+					return WithTokenFactory(BearerAuthorization, f), nil
 				},
 			},
 		),

--- a/basculehttp/bearerTokenFactory.go
+++ b/basculehttp/bearerTokenFactory.go
@@ -35,9 +35,10 @@ const (
 )
 
 var (
-	ErrorInvalidPrincipal = errors.New("invalid principal")
-	ErrorInvalidToken     = errors.New("token isn't valid")
-	ErrorUnexpectedClaims = errors.New("claims wasn't MapClaims as expected")
+	ErrEmptyValue       = errors.New("empty value")
+	ErrInvalidPrincipal = errors.New("invalid principal")
+	ErrInvalidToken     = errors.New("token isn't valid")
+	ErrUnexpectedClaims = errors.New("claims wasn't MapClaims as expected")
 
 	ErrNilResolver = errors.New("resolver cannot be nil")
 )
@@ -58,7 +59,7 @@ type BearerTokenFactory struct {
 // well, a Token of type "jwt" is returned.
 func (btf BearerTokenFactory) ParseAndValidate(ctx context.Context, _ *http.Request, _ bascule.Authorization, value string) (bascule.Token, error) {
 	if len(value) == 0 {
-		return nil, errors.New("empty value")
+		return nil, ErrEmptyValue
 	}
 
 	keyfunc := func(token *jwt.Token) (interface{}, error) {
@@ -79,34 +80,30 @@ func (btf BearerTokenFactory) ParseAndValidate(ctx context.Context, _ *http.Requ
 		Leeway:    btf.Leeway,
 	}
 
-	jwsToken, err := btf.Parser.ParseJWT(value, &leewayclaims, keyfunc)
+	jwtToken, err := btf.Parser.ParseJWT(value, &leewayclaims, keyfunc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse JWS: %v", err)
 	}
-	if !jwsToken.Valid {
-		return nil, ErrorInvalidToken
+	if !jwtToken.Valid {
+		return nil, ErrInvalidToken
 	}
 
-	claims, ok := jwsToken.Claims.(*bascule.ClaimsWithLeeway)
-
+	claims, ok := jwtToken.Claims.(*bascule.ClaimsWithLeeway)
 	if !ok {
-		return nil, fmt.Errorf("failed to parse JWS: %w", ErrorUnexpectedClaims)
+		return nil, fmt.Errorf("failed to parse JWS: %w", ErrUnexpectedClaims)
 	}
-
 	claimsMap, err := claims.GetMap()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get map of claims with object [%v]: %v", claims, err)
 	}
-
 	jwtClaims := bascule.NewAttributes(claimsMap)
-
 	principalVal, ok := jwtClaims.Get(jwtPrincipalKey)
 	if !ok {
-		return nil, fmt.Errorf("%w: principal value not found at key %v", ErrorInvalidPrincipal, jwtPrincipalKey)
+		return nil, fmt.Errorf("%w: principal value not found at key %v", ErrInvalidPrincipal, jwtPrincipalKey)
 	}
 	principal, ok := principalVal.(string)
 	if !ok {
-		return nil, fmt.Errorf("%w: principal value [%v] not a string", ErrorInvalidPrincipal, principalVal)
+		return nil, fmt.Errorf("%w: principal value [%v] not a string", ErrInvalidPrincipal, principalVal)
 	}
 
 	return bascule.NewToken("jwt", principal, jwtClaims), nil

--- a/basculehttp/bearerTokenFactory_test.go
+++ b/basculehttp/bearerTokenFactory_test.go
@@ -17,154 +17,133 @@
 
 package basculehttp
 
-//TODO: fix this test
-// func TestBearerTokenFactory(t *testing.T) {
-// 	parseFailErr := errors.New("parse fail test")
-// 	resolveFailErr := errors.New("resolve fail test")
-// 	validateFailErr := errors.New("validate fail test")
-// 	tests := []struct {
-// 		description     string
-// 		value           string
-// 		parseCalled     bool
-// 		parseErr        error
-// 		protectedCalled bool
-// 		protectedHeader jose.Protected
-// 		resolveCalled   bool
-// 		resolveErr      error
-// 		validateCalled  bool
-// 		validateErr     error
-// 		payloadCalled   bool
-// 		payloadClaims   interface{}
-// 		payloadOK       bool
-// 		expectedToken   bascule.Token
-// 		expectedErr     error
-// 	}{
-// 		{
-// 			description:     "Success",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected(map[string]interface{}{"alg": "HS256"}),
-// 			resolveCalled:   true,
-// 			validateCalled:  true,
-// 			payloadCalled:   true,
-// 			payloadClaims:   jws.Claims(map[string]interface{}{jwtPrincipalKey: "test"}),
-// 			payloadOK:       true,
-// 			expectedToken:   bascule.NewToken("jwt", "test", bascule.Attributes{jwtPrincipalKey: "test"}),
-// 			expectedErr:     nil,
-// 		},
-// 		{
-// 			description: "Empty Value Error",
-// 			value:       "",
-// 			expectedErr: errors.New("empty value"),
-// 		},
-// 		{
-// 			description: "Parse Failure Error",
-// 			value:       "abcd",
-// 			parseCalled: true,
-// 			parseErr:    parseFailErr,
-// 			expectedErr: parseFailErr,
-// 		},
-// 		{
-// 			description:     "No Protected Header Error",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected{},
-// 			expectedErr:     ErrorNoProtectedHeader,
-// 		},
-// 		{
-// 			description:     "No Signing Method Error",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected(map[string]interface{}{"alg": "abcd"}),
-// 			expectedErr:     ErrorNoSigningMethod,
-// 		},
-// 		{
-// 			description:     "Resolve Key Error",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected(map[string]interface{}{"alg": "HS256"}),
-// 			resolveCalled:   true,
-// 			resolveErr:      resolveFailErr,
-// 			expectedErr:     resolveFailErr,
-// 		},
-// 		{
-// 			description:     "Validate Error",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected(map[string]interface{}{"alg": "HS256"}),
-// 			resolveCalled:   true,
-// 			validateCalled:  true,
-// 			validateErr:     validateFailErr,
-// 			expectedErr:     validateFailErr,
-// 		},
-// 		{
-// 			description:     "Convert to Claims Error",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected(map[string]interface{}{"alg": "HS256"}),
-// 			resolveCalled:   true,
-// 			validateCalled:  true,
-// 			payloadCalled:   true,
-// 			payloadClaims:   55555,
-// 			payloadOK:       false,
-// 			expectedErr:     ErrorUnexpectedPayload,
-// 		},
-// 		{
-// 			description:     "Payload Principal Error",
-// 			value:           "abcd",
-// 			parseCalled:     true,
-// 			protectedCalled: true,
-// 			protectedHeader: jose.Protected(map[string]interface{}{"alg": "HS256"}),
-// 			resolveCalled:   true,
-// 			validateCalled:  true,
-// 			payloadCalled:   true,
-// 			payloadClaims:   jws.Claims(map[string]interface{}{"test": "test"}),
-// 			payloadOK:       true,
-// 			expectedErr:     ErrorUnexpectedPrincipal,
-// 		},
-// 	}
-// 	for _, tc := range tests {
-// 		t.Run(tc.description, func(t *testing.T) {
-// 			assert := assert.New(t)
-// 			r := new(key.MockResolver)
-// 			p := new(mockJWSParser)
-// 			jwsToken := new(mockJWS)
-// 			pair := new(key.MockPair)
-// 			if tc.parseCalled {
-// 				p.On("ParseJWS", mock.Anything).Return(jwsToken, tc.parseErr).Once()
-// 			}
-// 			if tc.protectedCalled {
-// 				jwsToken.On("Protected").Return(tc.protectedHeader).Once()
-// 			}
-// 			if tc.resolveCalled {
-// 				r.On("ResolveKey", mock.Anything, mock.Anything).Return(pair, tc.resolveErr).Once()
-// 			}
-// 			if tc.validateCalled {
-// 				jwsToken.On("Verify", mock.Anything, mock.Anything).Return(tc.validateErr).Once()
-// 				pair.On("Public").Return(nil).Once()
-// 			}
-// 			if tc.payloadCalled {
-// 				jwsToken.On("Payload").Return(tc.payloadClaims, tc.payloadOK).Once()
-// 			}
-// 			btf := BearerTokenFactory{
-// 				DefaultKeyId: "default key id",
-// 				Resolver:     r,
-// 				Parser:       p,
-// 			}
-// 			req := httptest.NewRequest("get", "/", nil)
-// 			token, err := btf.ParseAndValidate(context.Background(), req, "", tc.value)
-// 			assert.Equal(tc.expectedToken, token)
-// 			if tc.expectedErr == nil || err == nil {
-// 				assert.Equal(tc.expectedErr, err)
-// 			} else {
-// 				assert.Contains(err.Error(), tc.expectedErr.Error())
-// 			}
-// 		})
-// 	}
-// }
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/xmidt-org/bascule"
+	"github.com/xmidt-org/bascule/key"
+)
+
+func TestBearerTokenFactory(t *testing.T) {
+	parseFailErr := errors.New("parse fail test")
+	resolveFailErr := errors.New("resolve fail test")
+	tests := []struct {
+		description   string
+		value         string
+		parseCalled   bool
+		parseErr      error
+		resolveCalled bool
+		resolveErr    error
+		claims        jwt.Claims
+		validToken    bool
+		expectedToken bascule.Token
+		expectedErr   error
+	}{
+		{
+			description:   "Success",
+			value:         "abcd",
+			parseCalled:   true,
+			resolveCalled: true,
+			claims: &bascule.ClaimsWithLeeway{
+				MapClaims: jwt.MapClaims{jwtPrincipalKey: "test"},
+			},
+			validToken:    true,
+			expectedToken: bascule.NewToken("jwt", "test", bascule.BasicAttributes{jwtPrincipalKey: "test"}),
+			expectedErr:   nil,
+		},
+		{
+			description: "Empty Value Error",
+			value:       "",
+			expectedErr: ErrEmptyValue,
+		},
+		{
+			description: "Parse Failure Error",
+			value:       "abcd",
+			parseCalled: true,
+			parseErr:    parseFailErr,
+			expectedErr: parseFailErr,
+		},
+		{
+			description:   "Resolve Key Error",
+			value:         "abcd",
+			parseCalled:   true,
+			resolveCalled: true,
+			resolveErr:    resolveFailErr,
+			expectedErr:   resolveFailErr,
+		},
+		{
+			description:   "Invalid Token Error",
+			value:         "abcd",
+			parseCalled:   true,
+			resolveCalled: true,
+			validToken:    false,
+			expectedErr:   ErrInvalidToken,
+		},
+		{
+			description:   "Convert to Claims Error",
+			value:         "abcd",
+			parseCalled:   true,
+			resolveCalled: true,
+			validToken:    true,
+			expectedErr:   ErrUnexpectedClaims,
+		},
+		{
+			description:   "Get Principal Error",
+			value:         "abcd",
+			parseCalled:   true,
+			resolveCalled: true,
+			validToken:    true,
+			claims:        &bascule.ClaimsWithLeeway{},
+			expectedErr:   ErrInvalidPrincipal,
+		},
+		{
+			description:   "Non-string Principal Error",
+			value:         "abcd",
+			parseCalled:   true,
+			resolveCalled: true,
+			validToken:    true,
+			claims: &bascule.ClaimsWithLeeway{
+				MapClaims: jwt.MapClaims{jwtPrincipalKey: 55.0},
+			},
+			expectedErr: ErrInvalidPrincipal,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			r := new(key.MockResolver)
+			p := new(mockParser)
+			pair := new(key.MockPair)
+			if tc.parseCalled {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, tc.claims)
+				token.Valid = tc.validToken
+				p.On("ParseJWT", mock.Anything, mock.Anything, mock.Anything).Return(token, tc.parseErr).Once()
+			}
+			if tc.resolveCalled {
+				r.On("ResolveKey", mock.Anything, mock.Anything).Return(pair, tc.resolveErr).Once()
+				if tc.resolveErr == nil {
+					pair.On("Public").Return(nil).Once()
+				}
+			}
+			btf := BearerTokenFactory{
+				DefaultKeyID: "default key id",
+				Resolver:     r,
+				Parser:       p,
+			}
+			req := httptest.NewRequest("get", "/", nil)
+			token, err := btf.ParseAndValidate(context.Background(), req, "", tc.value)
+			assert.Equal(tc.expectedToken, token)
+			if tc.expectedErr == nil || err == nil {
+				assert.Equal(tc.expectedErr, err)
+			} else {
+				assert.Contains(err.Error(), tc.expectedErr.Error())
+			}
+		})
+	}
+}

--- a/basculehttp/constructor.go
+++ b/basculehttp/constructor.go
@@ -185,7 +185,9 @@ func WithHeaderDelimiter(delimiter string) COption {
 // WithTokenFactory sets the TokenFactory for the constructor to use.
 func WithTokenFactory(key bascule.Authorization, tf TokenFactory) COption {
 	return func(c *constructor) {
-		c.authorizations[key] = tf
+		if tf != nil {
+			c.authorizations[key] = tf
+		}
 	}
 }
 
@@ -193,7 +195,9 @@ func WithTokenFactory(key bascule.Authorization, tf TokenFactory) COption {
 // If no logger is set, nothing is logged.
 func WithCLogger(getLogger func(context.Context) log.Logger) COption {
 	return func(c *constructor) {
-		c.getLogger = getLogger
+		if getLogger != nil {
+			c.getLogger = getLogger
+		}
 	}
 }
 
@@ -210,7 +214,9 @@ func WithParseURLFunc(parseURL ParseURL) COption {
 // WithCErrorResponseFunc sets the function that is called when an error occurs.
 func WithCErrorResponseFunc(f OnErrorResponse) COption {
 	return func(c *constructor) {
-		c.onErrorResponse = f
+		if f != nil {
+			c.onErrorResponse = f
+		}
 	}
 }
 
@@ -218,7 +224,9 @@ func WithCErrorResponseFunc(f OnErrorResponse) COption {
 // bascule errors into the appropriate HTTP response.
 func WithCErrorHTTPResponseFunc(f OnErrorHTTPResponse) COption {
 	return func(c *constructor) {
-		c.onErrorHTTPResponse = f
+		if f != nil {
+			c.onErrorHTTPResponse = f
+		}
 	}
 }
 

--- a/basculehttp/constructor_test.go
+++ b/basculehttp/constructor_test.go
@@ -35,6 +35,7 @@ func TestConstructor(t *testing.T) {
 	c := NewConstructor(
 		WithHeaderName(testHeader),
 		WithHeaderDelimiter(testDelimiter),
+		nil,
 		WithTokenFactory("Basic", BasicTokenFactory{"codex": "codex"}),
 		WithCLogger(func(_ context.Context) log.Logger {
 			return log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
@@ -47,6 +48,7 @@ func TestConstructor(t *testing.T) {
 		WithHeaderName(""),
 		WithHeaderDelimiter(""),
 		WithCLogger(func(_ context.Context) log.Logger { return nil }),
+		WithParseURLFunc(CreateRemovePrefixURLFunc("", nil)),
 	)
 	tests := []struct {
 		description        string

--- a/basculehttp/enforcer.go
+++ b/basculehttp/enforcer.go
@@ -129,14 +129,18 @@ func NewEnforcer(options ...EOption) func(http.Handler) http.Handler {
 // value in the rules map.
 func WithNotFoundBehavior(behavior NotFoundBehavior) EOption {
 	return func(e *enforcer) {
-		e.notFoundBehavior = behavior
+		if behavior > 0 {
+			e.notFoundBehavior = behavior
+		}
 	}
 }
 
 // WithRules sets the validator to be used for a given Authorization value.
 func WithRules(key bascule.Authorization, v bascule.Validator) EOption {
 	return func(e *enforcer) {
-		e.rules[key] = v
+		if v != nil {
+			e.rules[key] = v
+		}
 	}
 }
 
@@ -144,14 +148,18 @@ func WithRules(key bascule.Authorization, v bascule.Validator) EOption {
 // If no logger is set, nothing is logged.
 func WithELogger(getLogger func(context.Context) log.Logger) EOption {
 	return func(e *enforcer) {
-		e.getLogger = getLogger
+		if getLogger != nil {
+			e.getLogger = getLogger
+		}
 	}
 }
 
 // WithEErrorResponseFunc sets the function that is called when an error occurs.
 func WithEErrorResponseFunc(f OnErrorResponse) EOption {
 	return func(e *enforcer) {
-		e.onErrorResponse = f
+		if f != nil {
+			e.onErrorResponse = f
+		}
 	}
 }
 

--- a/basculehttp/errorResponse.go
+++ b/basculehttp/errorResponse.go
@@ -79,9 +79,6 @@ func ProvideOnErrorHTTPResponse() fx.Option {
 		fx.Annotated{
 			Group: "bascule_constructor_options",
 			Target: func(in OnErrorHTTPResponseIn) COption {
-				if in.R == nil {
-					return nil
-				}
 				return WithCErrorHTTPResponseFunc(in.R)
 			},
 		},

--- a/basculehttp/log_test.go
+++ b/basculehttp/log_test.go
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package basculehttp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestGetZapLogger(t *testing.T) {
+	l := zap.NewNop()
+	f := getZapLogger(func(_ context.Context) *zap.Logger {
+		return l
+	})
+	result := f(context.Background())
+	assert.NotNil(t, result)
+	assert.NotPanics(t, func() {
+		result.Log("msg", "testing", "error", "nope", "level", "debug")
+	})
+}

--- a/basculehttp/metricListener.go
+++ b/basculehttp/metricListener.go
@@ -19,9 +19,7 @@ package basculehttp
 
 import (
 	"errors"
-	"time"
 
-	"github.com/SermoDigital/jose/jwt"
 	"github.com/justinas/alice"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xmidt-org/bascule"
@@ -33,20 +31,16 @@ const (
 )
 
 // MetricListener keeps track of request authentication and authorization using
-// metrics.  When a request is successful, histograms are updated to mark the
-// time distance from nbf and exp as well as to mark the success in a counter.
-// Upon failure, the counter is incremented to indicate such failure and the
-// reason why.  MetricListener implements the Listener and has an
-// OnErrorResponse function in order for the metrics to be updated at the
-// correct time.
+// metrics. A counter is updated on success and failure to reflect the outcome
+// and reason for failure, if applicable. MetricListener implements the Listener
+// and has an OnErrorResponse function in order for the metrics to be updated at
+// the correct time.
 type MetricListener struct {
-	server    string
-	expLeeway time.Duration
-	nbfLeeway time.Duration
-	measures  *AuthValidationMeasures
+	server   string
+	measures *AuthValidationMeasures
 }
 
-// Option is how the MetricListener is be configured.
+// Option is how the MetricListener is configured.
 type Option func(m *MetricListener)
 
 // MetricListenerOptionsIn is an uber fx wired struct that can be used to build
@@ -57,19 +51,10 @@ type MetricListenerOptionsIn struct {
 	Options  []Option `group:"bascule_metric_listener_options"`
 }
 
-// LeewayIn is an uber fx wired struct that provides a bascule leeway, which can
-// be parsed into an Option.
-type LeewayIn struct {
-	fx.In
-	L bascule.Leeway `name:"jwt_leeway" optional:"true"`
-}
-
 // OnAuthenticated is called after a request passes through the constructor and
 // enforcer successfully.  It updates various metrics related to the accepted
 // request.
 func (m *MetricListener) OnAuthenticated(auth bascule.Authentication) {
-	now := time.Now()
-
 	if m.measures == nil {
 		return // measure tools are not defined, skip
 	}
@@ -84,33 +69,6 @@ func (m *MetricListener) OnAuthenticated(auth bascule.Authentication) {
 			OutcomeLabel: "Accepted",
 		}).
 		Add(1)
-
-	c, ok := auth.Token.Attributes().Get("claims")
-	if !ok {
-		return // if there aren't any claims, skip
-	}
-	claims, ok := c.(jwt.Claims)
-	if !ok {
-		return // if claims aren't what we expect, skip
-	}
-
-	//how far did we land from the NBF (in seconds): ie. -1 means 1 sec before, 1 means 1 sec after
-	if nbf, nbfPresent := claims.NotBefore(); nbfPresent {
-		nbf = nbf.Add(-m.nbfLeeway)
-		offsetToNBF := now.Sub(nbf).Seconds()
-		m.measures.NBFHistogram.
-			With(prometheus.Labels{ServerLabel: m.server}).
-			Observe(offsetToNBF)
-	}
-
-	//how far did we land from the EXP (in seconds): ie. -1 means 1 sec before, 1 means 1 sec after
-	if exp, expPresent := claims.Expiration(); expPresent {
-		exp = exp.Add(m.expLeeway)
-		offsetToEXP := now.Sub(exp).Seconds()
-		m.measures.EXPHistogram.
-			With(prometheus.Labels{ServerLabel: m.server}).
-			Observe(offsetToEXP)
-	}
 }
 
 // OnErrorResponse is called if the constructor or enforcer have a problem with
@@ -123,22 +81,6 @@ func (m *MetricListener) OnErrorResponse(e ErrorResponseReason, _ error) {
 	m.measures.ValidationOutcome.
 		With(prometheus.Labels{ServerLabel: m.server, OutcomeLabel: e.String()}).
 		Add(1)
-}
-
-// WithExpLeeway provides the exp leeway to be used when calculating the
-// request's offset from the exp time.
-func WithExpLeeway(e time.Duration) Option {
-	return func(m *MetricListener) {
-		m.expLeeway = e
-	}
-}
-
-// WithNbfLeeway provides the nbf leeway to be used when calculating the
-// request's offset from the nbf time.
-func WithNbfLeeway(n time.Duration) Option {
-	return func(m *MetricListener) {
-		m.nbfLeeway = n
-	}
 }
 
 // WithServer provides the server label value to be used by all MetricListener
@@ -174,19 +116,6 @@ func NewMetricListener(m *AuthValidationMeasures, options ...Option) (*MetricLis
 // needed for adding it into various middleware.
 func ProvideMetricListener() fx.Option {
 	return fx.Provide(
-		fx.Annotated{
-			Group: "bascule_metric_listener_options,flatten",
-			Target: func(in LeewayIn) []Option {
-				os := []Option{}
-				if in.L.EXP > 0 {
-					os = append(os, WithExpLeeway(time.Duration(in.L.EXP)))
-				}
-				if in.L.NBF > 0 {
-					os = append(os, WithNbfLeeway(time.Duration(in.L.NBF)))
-				}
-				return os
-			},
-		},
 		fx.Annotated{
 			Name: "bascule_metric_listener",
 			Target: func(in MetricListenerOptionsIn) (*MetricListener, error) {

--- a/basculehttp/metricListener.go
+++ b/basculehttp/metricListener.go
@@ -55,18 +55,15 @@ type MetricListenerOptionsIn struct {
 // enforcer successfully.  It updates various metrics related to the accepted
 // request.
 func (m *MetricListener) OnAuthenticated(auth bascule.Authentication) {
-	if m.measures == nil {
-		return // measure tools are not defined, skip
-	}
-
+	outcome := AcceptedOutcome
+	// this is weird and we should take note of it.
 	if auth.Token == nil {
-		return
+		outcome = EmptyOutcome
 	}
-
 	m.measures.ValidationOutcome.
 		With(prometheus.Labels{
 			ServerLabel:  m.server,
-			OutcomeLabel: "Accepted",
+			OutcomeLabel: outcome,
 		}).
 		Add(1)
 }
@@ -75,9 +72,6 @@ func (m *MetricListener) OnAuthenticated(auth bascule.Authentication) {
 // authenticating/authorizing the request.  The ErrorResponseReason is used as
 // the outcome label value in a metric.
 func (m *MetricListener) OnErrorResponse(e ErrorResponseReason, _ error) {
-	if m.measures == nil {
-		return
-	}
 	m.measures.ValidationOutcome.
 		With(prometheus.Labels{ServerLabel: m.server, OutcomeLabel: e.String()}).
 		Add(1)

--- a/basculehttp/metricListener_test.go
+++ b/basculehttp/metricListener_test.go
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package basculehttp
+
+// TODO: add metric listener tests here.

--- a/basculehttp/metrics.go
+++ b/basculehttp/metrics.go
@@ -26,8 +26,6 @@ import (
 // Names for our metrics
 const (
 	AuthValidationOutcome = "auth_validation"
-	NBFHistogram          = "auth_from_nbf_seconds"
-	EXPHistogram          = "auth_from_exp_seconds"
 )
 
 // labels
@@ -39,8 +37,6 @@ const (
 // help messages
 const (
 	authValidationOutcomeHelpMsg = "Counter for success and failure reason results through bascule"
-	nbfHelpMsg                   = "Difference (in seconds) between time of JWT validation and nbf (including leeway)"
-	expHelpMsg                   = "Difference (in seconds) between time of JWT validation and exp (including leeway)"
 )
 
 // ProvideMetrics provides the metrics relevant to this package as uber/fx
@@ -54,18 +50,6 @@ func ProvideMetrics() fx.Option {
 				Help:        authValidationOutcomeHelpMsg,
 				ConstLabels: nil,
 			}, ServerLabel, OutcomeLabel),
-		touchstone.HistogramVec(
-			prometheus.HistogramOpts{
-				Name:    NBFHistogram,
-				Help:    nbfHelpMsg,
-				Buckets: []float64{-61, -11, -2, -1, 0, 9, 60}, // defines the upper inclusive (<=) bounds
-			}, ServerLabel),
-		touchstone.HistogramVec(
-			prometheus.HistogramOpts{
-				Name:    EXPHistogram,
-				Help:    expHelpMsg,
-				Buckets: []float64{-61, -11, -2, -1, 0, 9, 60},
-			}, ServerLabel),
 	)
 }
 
@@ -73,7 +57,5 @@ func ProvideMetrics() fx.Option {
 type AuthValidationMeasures struct {
 	fx.In
 
-	NBFHistogram      prometheus.ObserverVec `name:"auth_from_nbf_seconds"`
-	EXPHistogram      prometheus.ObserverVec `name:"auth_from_exp_seconds"`
 	ValidationOutcome *prometheus.CounterVec `name:"auth_validation"`
 }

--- a/basculehttp/metrics.go
+++ b/basculehttp/metrics.go
@@ -34,6 +34,12 @@ const (
 	ServerLabel  = "server"
 )
 
+// outcome values other than error response reasons
+const (
+	AcceptedOutcome = "accepted"
+	EmptyOutcome    = "accepted_but_empty"
+)
+
 // help messages
 const (
 	authValidationOutcomeHelpMsg = "Counter for success and failure reason results through bascule"

--- a/basculehttp/mocks_test.go
+++ b/basculehttp/mocks_test.go
@@ -18,100 +18,11 @@
 package basculehttp
 
 import (
-	"github.com/SermoDigital/jose"
-	"github.com/SermoDigital/jose/crypto"
-	"github.com/SermoDigital/jose/jws"
-	"github.com/SermoDigital/jose/jwt"
 	"github.com/stretchr/testify/mock"
 	"github.com/xmidt-org/bascule"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
-
-type mockJWS struct {
-	mock.Mock
-}
-
-var _ jwt.JWT = (*mockJWS)(nil)
-var _ jws.JWS = (*mockJWS)(nil)
-
-func (j *mockJWS) Claims() jwt.Claims {
-	arguments := j.Called()
-	return arguments.Get(0).(jwt.Claims)
-}
-
-func (j *mockJWS) Validate(key interface{}, method crypto.SigningMethod, v ...*jwt.Validator) error {
-	arguments := j.Called(key, method, v)
-	return arguments.Error(0)
-}
-
-func (j *mockJWS) Serialize(key interface{}) ([]byte, error) {
-	arguments := j.Called(key)
-	return arguments.Get(0).([]byte), arguments.Error(1)
-}
-
-func (j *mockJWS) Payload() interface{} {
-	arguments := j.Called()
-	return arguments.Get(0)
-}
-
-func (j *mockJWS) SetPayload(p interface{}) {
-	j.Called(p)
-}
-
-func (j *mockJWS) Protected() jose.Protected {
-	arguments := j.Called()
-	protected, _ := arguments.Get(0).(jose.Protected)
-	return protected
-}
-
-func (j *mockJWS) ProtectedAt(i int) jose.Protected {
-	arguments := j.Called(i)
-	return arguments.Get(0).(jose.Protected)
-}
-
-func (j *mockJWS) Header() jose.Header {
-	arguments := j.Called()
-	return arguments.Get(0).(jose.Header)
-}
-
-func (j *mockJWS) HeaderAt(i int) jose.Header {
-	arguments := j.Called(i)
-	return arguments.Get(0).(jose.Header)
-}
-
-func (j *mockJWS) Verify(key interface{}, method crypto.SigningMethod) error {
-	arguments := j.Called(key, method)
-	return arguments.Error(0)
-}
-
-func (j *mockJWS) VerifyMulti(keys []interface{}, methods []crypto.SigningMethod, o *jws.SigningOpts) error {
-	arguments := j.Called(keys, methods, o)
-	return arguments.Error(0)
-}
-
-func (j *mockJWS) VerifyCallback(fn jws.VerifyCallback, methods []crypto.SigningMethod, o *jws.SigningOpts) error {
-	arguments := j.Called(fn, methods, o)
-	return arguments.Error(0)
-}
-
-func (j *mockJWS) General(keys ...interface{}) ([]byte, error) {
-	arguments := j.Called(keys)
-	return arguments.Get(0).([]byte), arguments.Error(1)
-}
-
-func (j *mockJWS) Flat(key interface{}) ([]byte, error) {
-	arguments := j.Called(key)
-	return arguments.Get(0).([]byte), arguments.Error(1)
-}
-
-func (j *mockJWS) Compact(key interface{}) ([]byte, error) {
-	arguments := j.Called(key)
-	return arguments.Get(0).([]byte), arguments.Error(1)
-}
-
-func (j *mockJWS) IsJWT() bool {
-	arguments := j.Called()
-	return arguments.Bool(0)
-}
 
 // mockListener
 type mockListener struct {
@@ -120,4 +31,21 @@ type mockListener struct {
 
 func (l *mockListener) OnAuthenticated(a bascule.Authentication) {
 	l.Called(a)
+}
+
+// mock JWT parser
+type mockParser struct {
+	mock.Mock
+}
+
+// we want to test the parseFunc so it needs to be called here.
+func (p *mockParser) ParseJWT(token string, claims jwt.Claims, parseFunc jwt.Keyfunc) (*jwt.Token, error) {
+	args := p.Called(token, claims, parseFunc)
+	t := args.Get(0).(*jwt.Token)
+	err := args.Error(1)
+	if err != nil {
+		return t, err
+	}
+	_, err = parseFunc(t)
+	return t, err
 }

--- a/basculehttp/provide.go
+++ b/basculehttp/provide.go
@@ -41,7 +41,7 @@ func ProvideBasicAuth(key string) fx.Option {
 			fx.Annotated{
 				Group: "primary_bascule_enforcer_options",
 				Target: func() EOption {
-					return WithRules("Basic", basculechecks.AllowAll())
+					return WithRules(BasicAuthorization, basculechecks.AllowAll())
 				},
 			},
 		),
@@ -82,7 +82,7 @@ func ProvideBearerValidator() fx.Option {
 				if in.Capabilities != nil {
 					rules = append(rules, in.Capabilities)
 				}
-				return WithRules("Bearer", bascule.Validators(rules))
+				return WithRules(BearerAuthorization, bascule.Validators(rules))
 			},
 		},
 	)

--- a/basculehttp/provide.go
+++ b/basculehttp/provide.go
@@ -79,6 +79,9 @@ func ProvideBearerValidator() fx.Option {
 						rules = append(rules, v)
 					}
 				}
+				if len(rules) == 0 {
+					return nil
+				}
 				if in.Capabilities != nil {
 					rules = append(rules, in.Capabilities)
 				}

--- a/basculehttp/provide_test.go
+++ b/basculehttp/provide_test.go
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package basculehttp
+
+// TODO: add provide tests here.

--- a/basculehttp/urlParsing.go
+++ b/basculehttp/urlParsing.go
@@ -62,9 +62,6 @@ func ProvideParseURL() fx.Option {
 		fx.Annotated{
 			Group: "bascule_constructor_options",
 			Target: func(in ParseURLIn) COption {
-				if in.P == nil {
-					return nil
-				}
 				return WithParseURLFunc(in.P)
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/xmidt-org/bascule
 go 1.12
 
 require (
-	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-kit/kit v0.10.0
 	github.com/justinas/alice v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/spf13/cast v1.3.1
+	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xmidt-org/arrange v0.1.9
 	github.com/xmidt-org/sallust v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/Microsoft/go-winio v0.4.3/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2 h1:koK7z0nSsRiRiBWwa+E714Puh+DO+ZRdIyAXiXzL+lg=
 github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2/go.mod h1:ARgCUhI1MHQH+ONky/PAtmVHQrP5JlGY0F3poXOp/fA=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/key/resolverFactory.go
+++ b/key/resolverFactory.go
@@ -133,7 +133,7 @@ func ProvideResolver(key string, optional bool) fx.Option {
 		fx.Annotated{
 			Name: "key_resolver",
 			Target: func(in ResolverFactoryIn) (Resolver, error) {
-				if in.R == nil {
+				if in.R == nil || in.R.URI == "" {
 					if optional {
 						return nil, nil
 					}


### PR DESCRIPTION
Added/fixed unit tests in various bascule packages, especially related to code added in https://github.com/xmidt-org/bascule/pull/104.

Non-test code changes made along the way:
- Added nil checks in middleware options, so provide functions don't have to check.
- Renamed BearerTokenFactory errors.
- Realized MetricListener was very outdated and still using `SermoDigital` dependency (already removed from bascule a while ago). This led to removing two histograms we haven't been utilizing and generally updating MetricListener to make more sense.
- Updated some `Provide()` funcs to use constants we already had.

I still have two test files to fill out (included with `TODO`s), but if this seems long enough already I can put them in a new pr.