### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.11.0]
 - Refactored basculehttp to use Clortho instead of key package. [135](https://github.com/xmidt-org/bascule/pull/135)
 - Update dependencies. [131](https://github.com/xmidt-org/bascule/pull/131)
     -  [github.com/gorilla/sessions v1.2.1 cwe-613 no patch available](https://ossindex.sonatype.org/vulnerability/sonatype-2021-4899)
@@ -117,7 +119,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added constructor, enforcer, and listener alice decorators
 - Basic code and structure established
 
-[Unreleased]: https://github.com/xmidt-org/bascule/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/xmidt-org/bascule/compare/v0.11.0...HEAD
+[v0.11.0]: https://github.com/xmidt-org/bascule/compare/v0.10.2...v0.11.0
 [v0.10.2]: https://github.com/xmidt-org/bascule/compare/v0.10.1...v0.10.2
 [v0.10.1]: https://github.com/xmidt-org/bascule/compare/v0.10.0...v0.10.1
 [v0.10.0]: https://github.com/xmidt-org/bascule/compare/v0.9.0...v0.10.0


### PR DESCRIPTION
What's included:
- Refactored basculehttp to use Clortho instead of key package. [135](https://github.com/xmidt-org/bascule/pull/135)
- Update dependencies. [131](https://github.com/xmidt-org/bascule/pull/131)
    -  [github.com/gorilla/sessions v1.2.1 cwe-613 no patch available](https://ossindex.sonatype.org/vulnerability/sonatype-2021-4899)
- Update dependencies. [130](https://github.com/xmidt-org/bascule/pull/130)
- Update CI system. [129](https://github.com/xmidt-org/bascule/pull/129)
- Add new middleware for specifying the logger. [126](https://github.com/xmidt-org/bascule/pull/126)
- Added fields to SetLoggerLogger func and bumped cast, viper, arrange, and zap packages. [122](https://github.com/xmidt-org/bascule/pull/122)
- Removed "github.com/pkg/errors" dependency for "errors". [#116](https://github.com/xmidt-org/bascule/pull/116)
