### PR TITLE
Feature/token wrapping

### DIFF
--- a/authenticator_examples_test.go
+++ b/authenticator_examples_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package bascule
+
+import (
+	"context"
+	"fmt"
+)
+
+type Extra struct {
+	Name string
+	Age  int
+}
+
+func (e Extra) Principal() string { return e.Name }
+
+// ExampleJoinTokens_augment shows how to augment a Token as part
+// of authentication workflow.
+func ExampleJoinTokens_augment() {
+	original := StubToken("original")
+	authenticator, _ := NewAuthenticator[string](
+		WithTokenParsers(
+			StubTokenParser[string]{
+				Token: original,
+			},
+		),
+		WithValidators(
+			AsValidator[string](
+				func(t Token) (Token, error) {
+					// augment this token with extra information
+					return JoinTokens(t, Extra{Name: "extra", Age: 33}), nil
+				},
+			),
+		),
+	)
+
+	authenticated, _ := authenticator.Authenticate(
+		context.Background(),
+		"source",
+	)
+
+	fmt.Println("authenticated principal:", authenticated.Principal())
+
+	var extra Extra
+	if !TokenAs(authenticated, &extra) {
+		panic("token cannot be converted")
+	}
+
+	fmt.Println("extra.Name:", extra.Name)
+	fmt.Println("extra.Age:", extra.Age)
+
+	// Output:
+	// authenticated principal: original
+	// extra.Name: extra
+	// extra.Age: 33
+}

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -35,6 +35,34 @@ func (m *mockTokenWithCapabilities) ExpectCapabilities(caps ...string) *mock.Cal
 	return m.On("Capabilities").Return(caps)
 }
 
+type mockTokenUnwrapOne struct {
+	mockToken
+}
+
+func (m *mockTokenUnwrapOne) Unwrap() Token {
+	args := m.Called()
+	t, _ := args.Get(0).(Token)
+	return t
+}
+
+func (m *mockTokenUnwrapOne) ExpectUnwrap(t Token) *mock.Call {
+	return m.On("Unwrap").Return(t)
+}
+
+type mockTokenUnwrapMany struct {
+	mockToken
+}
+
+func (m *mockTokenUnwrapMany) Unwrap() []Token {
+	args := m.Called()
+	t, _ := args.Get(0).([]Token)
+	return t
+}
+
+func (m *mockTokenUnwrapMany) ExpectUnwrap(t ...Token) *mock.Call {
+	return m.On("Unwrap").Return(t)
+}
+
 type mockValidator[S any] struct {
 	mock.Mock
 }


### PR DESCRIPTION
This PR implements Token wrapping, a feature very similar to the `errors` package.

It's often true that authentication needs to augment a Token.  This need can arise because of reading from an external database, needing to add attributes for the application layer to process, etc.  You can now supply an `Unwrap` method in custom tokens to communicate nesting.  The `TokenAs` function allows client code to extract custom types from tokens in a way much like `errors.As` does for errors.